### PR TITLE
Query settings if xdp is running and watch its service being registered

### DIFF
--- a/src/qadwaitadecorations.h
+++ b/src/qadwaitadecorations.h
@@ -81,6 +81,7 @@ private:
     void updateColors(bool useDarkColors);
     void updateIcons();
     void updateTitlebarLayout(const QString &layout);
+    void querySettings();
     QRect windowContentGeometry() const;
 
     void forceRepaint();


### PR DESCRIPTION
Do not attempt to query settings when xdg-desktop-portal is not running yet, instead watch for its DBus service to appear and query the settings afterwards so in case an app is started before xdg-desktop-portal, it can still apply correct style.

Fixes #28