### PR TITLE
Use bold font weight for titles

### DIFF
--- a/src/qadwaitadecorations.cpp
+++ b/src/qadwaitadecorations.cpp
@@ -106,6 +106,7 @@ QAdwaitaDecorations::QAdwaitaDecorations()
         m_font = std::make_unique<QFont>(*font);
     if (!m_font)
         m_font = std::make_unique<QFont>(QLatin1String("Sans"), 10);
+    m_font->setBold(true);
 
     QTimer::singleShot(0, this, &QAdwaitaDecorations::initConfiguration);
 }


### PR DESCRIPTION
The small change that should resolve #51. Tested locally with the QT6 version of qBittorrent.

Before:
![before](https://github.com/FedoraQt/QAdwaitaDecorations/assets/68248740/07e4a835-36c7-4f7e-bd31-321ed58fdb43)

After:
![after](https://github.com/FedoraQt/QAdwaitaDecorations/assets/68248740/d5588045-5e55-4526-b936-4123eb5021dd)
