### PR TITLE
Titlebar: use bold font when detected over portal

### DIFF
--- a/src/qadwaitadecorations.cpp
+++ b/src/qadwaitadecorations.cpp
@@ -145,6 +145,17 @@ void QAdwaitaDecorations::initConfiguration()
                         if (!buttonLayout.isEmpty()) {
                             updateTitlebarLayout(buttonLayout);
                         }
+                        // Workaround for QGtkStyle not having correct titlebar font
+                        // This is not going to be very precise as I want to avoid dependency on
+                        // Pango which we had in QGnomePlatform, but at least make the font bold
+                        // if detected.
+                        const QString titlebarFont =
+                                settings.value(QLatin1String("org.gnome.desktop.wm.preferences"))
+                                        .value(QLatin1String("titlebar-font"))
+                                        .toString();
+                        if (titlebarFont.contains(QLatin1String("bold"), Qt::CaseInsensitive)) {
+                            m_font->setBold(true);
+                        }
                     }
                 }
                 watcher->deleteLater();


### PR DESCRIPTION
QGtkStyle doesn't give us information whether titlebar font is bold or not so make a simple check over the Settings portal.

Fixes #51