### PR TITLE
Fixed window borders

### DIFF
--- a/src/qadwaitadecorations.cpp
+++ b/src/qadwaitadecorations.cpp
@@ -383,7 +383,6 @@ void QAdwaitaDecorations::paint(QPaintDevice *device)
     const QColor foregroundColor = active ? m_colors[Foreground] : m_colors[ForegroundInactive];
 
     QPainter p(device);
-    p.setRenderHint(QPainter::Antialiasing);
 
 #ifdef HAS_QT6_SUPPORT
     // Shadows
@@ -463,14 +462,14 @@ void QAdwaitaDecorations::paint(QPaintDevice *device)
 #endif
             path.addRect(margins().left(), margins().bottom(), titleBarWidth, margins().top());
         else
-            path.addRoundedRect(margins().left(), margins().bottom(), titleBarWidth,
+            path.addRoundedRect(margins().left() - ceWindowBorderWidth, margins().bottom(), titleBarWidth + ceWindowBorderWidth,
                                 margins().top() + ceCornerRadius, ceCornerRadius, ceCornerRadius);
 
         p.save();
         p.setPen(borderColor);
         p.fillPath(path.simplified(), backgroundColor);
         p.drawPath(path);
-        p.drawRect(margins().left(), margins().top(), titleBarWidth, borderRectHeight);
+        p.drawRect(margins().left() - ceWindowBorderWidth, margins().top(), titleBarWidth + ceWindowBorderWidth, borderRectHeight);
         p.restore();
     }
 
@@ -479,7 +478,7 @@ void QAdwaitaDecorations::paint(QPaintDevice *device)
         p.save();
         p.setPen(active ? m_colors[Border] : m_colors[BorderInactive]);
         p.drawLine(QLineF(margins().left(), margins().top() - ceTitlebarSeperatorWidth,
-                          surfaceRect.width() - margins().right(),
+                          surfaceRect.width() - margins().right() - ceWindowBorderWidth,
                           margins().top() - ceTitlebarSeperatorWidth));
         p.restore();
     }


### PR DESCRIPTION
Currently, the window border routine draws border of `1px` and ignores the `ceWindowBorderWidth` variable (which is indeed set to `1`). The border should look wrong, because it shouldn't be drawn in the left part of the window, as the routine doesn't account for it.

To my surprise, however, windows had a border on the left part. After a while I figured it only looks right because the antialiasing makes all `1px` lines as `2px`. I noticed this while triying to fix the titlebar border being noticeably `2px` thick. Here is a comparison with no shadow and a highlighted border:

![Schermata del 2024-06-04 18-10-55](https://github.com/FedoraQt/QAdwaitaDecorations/assets/106469113/f1ce3a8f-bd29-4ba3-90e0-ab788beea641)

Notice how the titlebar border "leaks" onto the window border for a few pixels, and how all the borders except the title bar are transparent. Also the titlebar separator cuts the window border. Here is the window with my patch, removing antialiasing and accounting for a window border.

![Schermata del 2024-06-04 18-13-38](https://github.com/FedoraQt/QAdwaitaDecorations/assets/106469113/6fa24c21-0816-484f-b8be-11a0a4070b16)

The borders aren't transparent anymore, the titlebar border is the same thickness as the rest, and the title bar stops where it should. One thing that is missing is the fact that the border is `1px` regardless of the `ceWindowBorderSize` because the pen is not set.