### PR TITLE
Fixed all wrong layouts

### DIFF
--- a/src/qadwaitadecorations.cpp
+++ b/src/qadwaitadecorations.cpp
@@ -263,8 +263,10 @@ void QAdwaitaDecorations::updateTitlebarLayout(const QString &layout)
             m_buttons.insert(Close, pos);
         } else if (button == QLatin1String("maximize")) {
             m_buttons.insert(Maximize, pos);
-        } else {
+        } else if (button == QLatin1String("minimize")) {
             m_buttons.insert(Minimize, pos);
+        } else {
+            continue;
         }
         pos++;
     }


### PR DESCRIPTION
This patch fixes wrong layouts with ":", ",close:", ":close,", ":minimize,,maximize,,close,,", etc.