### PR TITLE
Match Adwaita current corner radius

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "workbench.colorCustomizations": {
+        "terminal.background": "#00000000",
+        "minimap.background": "#00000000",
+        "scrollbar.shadow": "#00000000"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "workbench.colorCustomizations": {
-        "terminal.background": "#00000000",
-        "minimap.background": "#00000000",
-        "scrollbar.shadow": "#00000000"
-    }
-}

--- a/src/qadwaitadecorations.cpp
+++ b/src/qadwaitadecorations.cpp
@@ -48,7 +48,7 @@
 static constexpr int ceButtonSpacing = 12;
 static constexpr int ceButtonWidth = 24;
 static constexpr int ceCornerRadius = 15;
-static constexpr int ceShadowsWidth = 20;
+static constexpr int ceShadowsWidth = 10;
 static constexpr int ceTitlebarHeight = 38;
 static constexpr int ceWindowBorderWidth = 1;
 

--- a/src/qadwaitadecorations.cpp
+++ b/src/qadwaitadecorations.cpp
@@ -47,8 +47,8 @@
 
 static constexpr int ceButtonSpacing = 12;
 static constexpr int ceButtonWidth = 24;
-static constexpr int ceCornerRadius = 12;
-static constexpr int ceShadowsWidth = 10;
+static constexpr int ceCornerRadius = 15;
+static constexpr int ceShadowsWidth = 20;
 static constexpr int ceTitlebarHeight = 38;
 static constexpr int ceWindowBorderWidth = 1;
 


### PR DESCRIPTION
This is just a simple change to match Adwaita current corner radius of 15 instead of 12.

Current version (Radius 12)
<img width="513" height="206" alt="Screenshot From 2026-04-04 01-09-25" src="https://github.com/user-attachments/assets/ba67d7af-8cbe-42b3-8ce1-6b3798828542" />

Adjusted:
<img width="480" height="270" alt="Screenshot From 2026-04-04 01-19-26" src="https://github.com/user-attachments/assets/28eadb0f-0469-4426-aae9-296ed02faa0e" />
